### PR TITLE
[Mathijs] Task 11 (Windsurf): DOC Add link to plot_gpr_co2.py example in GaussianProcessRegressor docstring

### DIFF
--- a/sklearn/gaussian_process/_gpr.py
+++ b/sklearn/gaussian_process/_gpr.py
@@ -187,6 +187,11 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
     0.3680...
     >>> gpr.predict(X[:2,:], return_std=True)
     (array([653.0..., 592.1...]), array([316.6..., 316.6...]))
+
+    For an example of complex kernel engineering and hyperparameter optimization
+    with Gaussian Process Regression, see
+    :ref:`sphx_glr_auto_examples_gaussian_process_plot_gpr_co2.py`.
+
     """
 
     _parameter_constraints: dict = {
@@ -594,8 +599,11 @@ class GaussianProcessRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             y_train = y_train[:, np.newaxis]
 
         # Alg 2.1, page 19, line 3 -> alpha = L^T \ (L \ y)
-        alpha = cho_solve((L, GPR_CHOLESKY_LOWER), y_train, check_finite=False)
-
+        alpha = cho_solve(
+            (L, GPR_CHOLESKY_LOWER),
+            y_train,
+            check_finite=False,
+        )
         # Alg 2.1, page 19, line 7
         # -0.5 . y^T . alpha - sum(log(diag(L))) - n_samples / 2 log(2*pi)
         # y is originally thought to be a (1, n_samples) row vector. However,


### PR DESCRIPTION
This PR adds a link to the plot_gpr_co2.py example in the docstring of the GaussianProcessRegressor class. This example demonstrates complex kernel engineering and hyperparameter optimization with Gaussian Process Regression for forecasting CO2 concentration, which is valuable for users looking to implement more advanced applications.

This is part of the work for issue #30621 to improve documentation by making examples more discoverable.

Checklist:

[x] I have added a link to an existing example
[x] The link is placed in a relevant location within the docstring
[x] Pre-commit hooks pass
[x] The example is valuable to users of this class
Fixes: #30621 (partially)