### PR TITLE
[Mathijs] Task 13 (Augment): TST improve error messages in _check_transformer

### DIFF
--- a/sklearn/utils/estimator_checks.py
+++ b/sklearn/utils/estimator_checks.py
@@ -2068,10 +2068,18 @@ def _check_transformer(name, transformer_orig, X, y):
 
     if isinstance(X_pred, tuple):
         for x_pred in X_pred:
-            assert x_pred.shape[0] == n_samples
+            assert x_pred.shape[0] == n_samples, (
+                f"Transformer {name}.fit_transform output inside tuple has wrong "
+                f"number of samples. Expected {n_samples}, got {x_pred.shape[0]}. "
+                f"Transformers must preserve sample count."
+            )
     else:
         # check for consistent n_samples
-        assert X_pred.shape[0] == n_samples
+        assert X_pred.shape[0] == n_samples, (
+            f"Transformer {name}.fit_transform output has wrong number of samples. "
+            f"Expected {n_samples}, got {X_pred.shape[0]}. Transformers must "
+            f"preserve sample count."
+        )
 
     if hasattr(transformer, "transform"):
         if name in CROSS_DECOMPOSITION:
@@ -2115,8 +2123,16 @@ def _check_transformer(name, transformer_orig, X, y):
                 err_msg="consecutive fit_transform outcomes not consistent in %s"
                 % transformer,
             )
-            assert _num_samples(X_pred2) == n_samples
-            assert _num_samples(X_pred3) == n_samples
+            assert _num_samples(X_pred2) == n_samples, (
+                f"Transformer {name}.transform output has wrong number of samples. "
+                f"Expected {n_samples}, got {_num_samples(X_pred2)}. Transformers "
+                f"must preserve sample count."
+            )
+            assert _num_samples(X_pred3) == n_samples, (
+                f"Transformer {name}.fit_transform output has wrong number of "
+                f"samples. Expected {n_samples}, got {_num_samples(X_pred3)}. "
+                f"Transformers must preserve sample count."
+            )
 
         # raises error on malformed input for transform
         if (


### PR DESCRIPTION
This PR improves the error messages in the `_check_transformer` function in `estimator_checks.py`. The changes make the assert messages more informative and helpful for developers by:

1. Adding clear error messages to all assert statements that were previously missing them
2. Including specific information about which method is being tested (fit_transform or transform)
3. Providing the expected and actual values to help with debugging
4. Adding guidance that transformers must preserve sample count
5. Using a consistent style for all error messages

These improvements follow the pattern established in PR #30235, which improved error messages in `check_classifier_multioutput`.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author