### PR TITLE
[Tomer] Task 15 (Cursor): Remove deprecated code

### DIFF
--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -87,7 +87,7 @@ class BaseSGD(SparseCoefMixin, BaseEstimator, metaclass=ABCMeta):
         "verbose": ["verbose"],
         "random_state": ["random_state"],
         "warm_start": ["boolean"],
-        "average": [Interval(Integral, 0, None, closed="left"), "boolean"],
+        "average": [Interval(Integral, 1, None, closed="left"), "boolean"],
     }
 
     def __init__(
@@ -598,15 +598,7 @@ class BaseSGDClassifier(LinearClassifierMixin, BaseSGD, metaclass=ABCMeta):
         )
 
         if first_call:
-            # TODO(1.7) remove 0 from average parameter constraint
-            if not isinstance(self.average, (bool, np.bool_)) and self.average == 0:
-                warnings.warn(
-                    (
-                        "Passing average=0 to disable averaging is deprecated and will"
-                        " be removed in 1.7. Please use average=False instead."
-                    ),
-                    FutureWarning,
-                )
+            pass
 
         n_samples, n_features = X.shape
 
@@ -682,16 +674,6 @@ class BaseSGDClassifier(LinearClassifierMixin, BaseSGD, metaclass=ABCMeta):
         if hasattr(self, "classes_"):
             # delete the attribute otherwise _partial_fit thinks it's not the first call
             delattr(self, "classes_")
-
-        # TODO(1.7) remove 0 from average parameter constraint
-        if not isinstance(self.average, (bool, np.bool_)) and self.average == 0:
-            warnings.warn(
-                (
-                    "Passing average=0 to disable averaging is deprecated and will be "
-                    "removed in 1.7. Please use average=False instead."
-                ),
-                FutureWarning,
-            )
 
         # labels can be encoded as float, int, or string literals
         # np.unique sorts in asc order; largest class id is positive class
@@ -2388,15 +2370,7 @@ class SGDOneClassSVM(OutlierMixin, BaseSGD):
         )
 
         if first_call:
-            # TODO(1.7) remove 0 from average parameter constraint
-            if not isinstance(self.average, (bool, np.bool_)) and self.average == 0:
-                warnings.warn(
-                    (
-                        "Passing average=0 to disable averaging is deprecated and will"
-                        " be removed in 1.7. Please use average=False instead."
-                    ),
-                    FutureWarning,
-                )
+            pass
 
         n_features = X.shape[1]
 
@@ -2488,15 +2462,6 @@ class SGDOneClassSVM(OutlierMixin, BaseSGD):
         offset_init=None,
         sample_weight=None,
     ):
-        # TODO(1.7) remove 0 from average parameter constraint
-        if not isinstance(self.average, (bool, np.bool_)) and self.average == 0:
-            warnings.warn(
-                (
-                    "Passing average=0 to disable averaging is deprecated and will be "
-                    "removed in 1.7. Please use average=False instead."
-                ),
-                FutureWarning,
-            )
 
         if self.warm_start and hasattr(self, "coef_"):
             if coef_init is None:

--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -597,9 +597,6 @@ class BaseSGDClassifier(LinearClassifierMixin, BaseSGD, metaclass=ABCMeta):
             reset=first_call,
         )
 
-        if first_call:
-            pass
-
         n_samples, n_features = X.shape
 
         _check_partial_fit_first_call(self, classes)
@@ -2368,9 +2365,6 @@ class SGDOneClassSVM(OutlierMixin, BaseSGD):
             accept_large_sparse=False,
             reset=first_call,
         )
-
-        if first_call:
-            pass
 
         n_features = X.shape[1]
 

--- a/sklearn/linear_model/tests/test_sgd.py
+++ b/sklearn/linear_model/tests/test_sgd.py
@@ -2165,14 +2165,6 @@ def test_sgd_numerical_consistency(SGDEstimator):
     assert_allclose(sgd_64.coef_, sgd_32.coef_)
 
 
-# TODO(1.7): remove
-@pytest.mark.parametrize("Estimator", [SGDClassifier, SGDRegressor, SGDOneClassSVM])
-def test_passive_aggressive_deprecated_average(Estimator):
-    est = Estimator(average=0)
-    with pytest.warns(FutureWarning, match="average=0"):
-        est.fit(X, Y)
-
-
 def test_sgd_one_class_svm_estimator_type():
     """Check that SGDOneClassSVM has the correct estimator type.
 


### PR DESCRIPTION
# Remove average=0 deprecation warnings in stochastic gradient descent

## Description
This PR removes the deprecation warnings for using `average=0` in stochastic gradient descent estimators. The warnings were added in a previous version with a plan to remove them in version 1.7. This PR completes that plan by:

1. Updating the parameter validation to only accept boolean or integers > 0 for the `average` parameter
2. Removing all deprecation warnings in `BaseSGDClassifier._partial_fit`, `BaseSGDClassifier._fit`, `SGDOneClassSVM._partial_fit`, and `SGDOneClassSVM._fit`
3. Removing the test `test_passive_aggressive_deprecated_average` that was specifically testing the deprecation warning

## Checklist
- [x] I have followed the [contributing guidelines](https://scikit-learn.org/dev/developers/contributing.html)
- [x] I have given my PR a descriptive title
- [x] I have ensured that all tests pass
- [x] I have updated the documentation accordingly