### PR TITLE
[Mathijs] Task 16 (Augment): MAINT Merge short examples under examples/linear_model

### DIFF
--- a/doc/modules/linear_model.rst
+++ b/doc/modules/linear_model.rst
@@ -109,8 +109,8 @@ The complexity parameter :math:`\alpha \geq 0` controls the amount
 of shrinkage: the larger the value of :math:`\alpha`, the greater the amount
 of shrinkage and thus the coefficients become more robust to collinearity.
 
-.. figure:: ../auto_examples/linear_model/images/sphx_glr_plot_ridge_path_001.png
-   :target: ../auto_examples/linear_model/plot_ridge_path.html
+.. figure:: ../auto_examples/linear_model/images/sphx_glr_plot_regularization_paths_001.png
+   :target: ../auto_examples/linear_model/plot_regularization_paths.html
    :align: center
    :scale: 50%
 
@@ -148,7 +148,7 @@ the corresponding solver is chosen.
 .. rubric:: Examples
 
 * :ref:`sphx_glr_auto_examples_linear_model_plot_ols_ridge.py`
-* :ref:`sphx_glr_auto_examples_linear_model_plot_ridge_path.py`
+* :ref:`sphx_glr_auto_examples_linear_model_plot_regularization_paths.py`
 * :ref:`sphx_glr_auto_examples_inspection_plot_linear_model_coefficient_interpretation.py`
 
 Classification
@@ -510,8 +510,8 @@ The objective function to minimize is in this case
     \frac{\alpha(1-\rho)}{2} ||w||_2 ^ 2}
 
 
-.. figure:: ../auto_examples/linear_model/images/sphx_glr_plot_lasso_lasso_lars_elasticnet_path_002.png
-   :target: ../auto_examples/linear_model/plot_lasso_lasso_lars_elasticnet_path.html
+.. figure:: ../auto_examples/linear_model/images/sphx_glr_plot_regularization_paths_002.png
+   :target: ../auto_examples/linear_model/plot_regularization_paths.html
    :align: center
    :scale: 50%
 
@@ -521,7 +521,7 @@ The class :class:`ElasticNetCV` can be used to set the parameters
 .. rubric:: Examples
 
 * :ref:`sphx_glr_auto_examples_linear_model_plot_lasso_and_elasticnet.py`
-* :ref:`sphx_glr_auto_examples_linear_model_plot_lasso_lasso_lars_elasticnet_path.py`
+* :ref:`sphx_glr_auto_examples_linear_model_plot_regularization_paths.py`
 * :ref:`sphx_glr_auto_examples_linear_model_plot_elastic_net_precomputed_gram_matrix_with_weighted_samples.py`
 
 .. dropdown:: References
@@ -615,8 +615,8 @@ algorithm, and unlike the implementation based on coordinate descent,
 this yields the exact solution, which is piecewise linear as a
 function of the norm of its coefficients.
 
-.. figure:: ../auto_examples/linear_model/images/sphx_glr_plot_lasso_lasso_lars_elasticnet_path_001.png
-   :target: ../auto_examples/linear_model/plot_lasso_lasso_lars_elasticnet_path.html
+.. figure:: ../auto_examples/linear_model/images/sphx_glr_plot_regularization_paths_003.png
+   :target: ../auto_examples/linear_model/plot_regularization_paths.html
    :align: center
    :scale: 50%
 
@@ -631,7 +631,7 @@ function of the norm of its coefficients.
 
 .. rubric:: Examples
 
-* :ref:`sphx_glr_auto_examples_linear_model_plot_lasso_lasso_lars_elasticnet_path.py`
+* :ref:`sphx_glr_auto_examples_linear_model_plot_regularization_paths.py`
 
 The LARS algorithm provides the full path of the coefficients along
 the regularization parameter almost for free, thus a common operation
@@ -893,7 +893,7 @@ regularization.
 .. rubric:: Examples
 
 * :ref:`sphx_glr_auto_examples_linear_model_plot_logistic_l1_l2_sparsity.py`
-* :ref:`sphx_glr_auto_examples_linear_model_plot_logistic_path.py`
+* :ref:`sphx_glr_auto_examples_linear_model_plot_logistic_regression_overview.py`
 * :ref:`sphx_glr_auto_examples_linear_model_plot_logistic_multinomial.py`
 * :ref:`sphx_glr_auto_examples_linear_model_plot_sparse_logistic_regression_20newsgroups.py`
 * :ref:`sphx_glr_auto_examples_linear_model_plot_sparse_logistic_regression_mnist.py`

--- a/doc/modules/sgd.rst
+++ b/doc/modules/sgd.rst
@@ -64,8 +64,8 @@ descent learning routine which supports different loss functions and
 penalties for classification. Below is the decision boundary of a
 :class:`SGDClassifier` trained with the hinge loss, equivalent to a linear SVM.
 
-.. figure:: ../auto_examples/linear_model/images/sphx_glr_plot_sgd_separating_hyperplane_001.png
-   :target: ../auto_examples/linear_model/plot_sgd_separating_hyperplane.html
+.. figure:: ../auto_examples/linear_model/images/sphx_glr_plot_sgd_overview_003.png
+   :target: ../auto_examples/linear_model/plot_sgd_overview.html
    :align: center
    :scale: 75
 
@@ -157,8 +157,8 @@ below illustrates the OVA approach on the iris dataset.  The dashed
 lines represent the three OVA classifiers; the background colors show
 the decision surface induced by the three classifiers.
 
-.. figure:: ../auto_examples/linear_model/images/sphx_glr_plot_sgd_iris_001.png
-   :target: ../auto_examples/linear_model/plot_sgd_iris.html
+.. figure:: ../auto_examples/linear_model/images/sphx_glr_plot_sgd_overview_004.png
+   :target: ../auto_examples/linear_model/plot_sgd_overview.html
    :align: center
    :scale: 75
 
@@ -191,9 +191,7 @@ algorithm, available as a solver in :class:`LogisticRegression`.
 
 .. rubric:: Examples
 
-- :ref:`sphx_glr_auto_examples_linear_model_plot_sgd_separating_hyperplane.py`
-- :ref:`sphx_glr_auto_examples_linear_model_plot_sgd_iris.py`
-- :ref:`sphx_glr_auto_examples_linear_model_plot_sgd_weighted_samples.py`
+- :ref:`sphx_glr_auto_examples_linear_model_plot_sgd_overview.py`
 - :ref:`sphx_glr_auto_examples_svm_plot_separating_hyperplane_unbalanced.py`
   (See the Note in the example)
 
@@ -444,8 +442,8 @@ the regularization strength.
 All of the above loss functions can be regarded as an upper bound on the
 misclassification error (Zero-one loss) as shown in the Figure below.
 
-.. figure:: ../auto_examples/linear_model/images/sphx_glr_plot_sgd_loss_functions_001.png
-    :target: ../auto_examples/linear_model/plot_sgd_loss_functions.html
+.. figure:: ../auto_examples/linear_model/images/sphx_glr_plot_sgd_overview_001.png
+    :target: ../auto_examples/linear_model/plot_sgd_overview.html
     :align: center
     :scale: 75
 
@@ -462,8 +460,8 @@ parameter) include:
 The Figure below shows the contours of the different regularization terms
 in a 2-dimensional parameter space (:math:`m=2`) when :math:`R(w) = 1`.
 
-.. figure:: ../auto_examples/linear_model/images/sphx_glr_plot_sgd_penalties_001.png
-    :target: ../auto_examples/linear_model/plot_sgd_penalties.html
+.. figure:: ../auto_examples/linear_model/images/sphx_glr_plot_sgd_overview_002.png
+    :target: ../auto_examples/linear_model/plot_sgd_overview.html
     :align: center
     :scale: 75
 

--- a/examples/linear_model/README_MERGED_EXAMPLES.txt
+++ b/examples/linear_model/README_MERGED_EXAMPLES.txt
@@ -1,0 +1,29 @@
+# Merged Examples in linear_model
+
+This directory contains several merged examples that combine multiple smaller examples into comprehensive overviews:
+
+## 1. plot_sgd_overview.py
+This example combines the following original examples:
+- plot_sgd_loss_functions.py
+- plot_sgd_penalties.py
+- plot_sgd_separating_hyperplane.py
+- plot_sgd_iris.py
+- plot_sgd_weighted_samples.py
+
+It provides a comprehensive overview of Stochastic Gradient Descent (SGD) in scikit-learn, including loss functions, penalties, binary classification, multi-class classification, and sample weighting.
+
+## 2. plot_logistic_regression_overview.py
+This example combines the following original examples:
+- plot_logistic.py
+- plot_logistic_path.py
+
+It provides an overview of logistic regression, including the basic logistic function and regularization paths for L1-regularized logistic regression.
+
+## 3. plot_regularization_paths.py
+This example combines the following original examples:
+- plot_ridge_path.py
+- plot_lasso_lasso_lars_elasticnet_path.py
+
+It provides a comprehensive overview of regularization paths for different linear models, including Ridge, Lasso, Lasso-LARS, and Elastic Net.
+
+The original examples have been preserved for backward compatibility, but references in the documentation and codebase have been updated to point to these new merged examples.

--- a/examples/linear_model/plot_logistic_regression_overview.py
+++ b/examples/linear_model/plot_logistic_regression_overview.py
@@ -1,0 +1,141 @@
+"""
+==============================================
+Logistic Regression - Overview
+==============================================
+
+This example illustrates various aspects of Logistic Regression in scikit-learn:
+
+1. **Basic Logistic Function**: Visualization of the logistic function and comparison
+   with linear regression on a synthetic dataset.
+2. **Regularization Path**: Demonstration of L1-regularized logistic regression and
+   how coefficients change with regularization strength.
+
+Logistic regression is a linear model for classification that models the probabilities
+of the outcomes using the logistic function. It's widely used for binary classification
+problems, though it can be extended to multi-class classification as well.
+"""
+
+# Authors: The scikit-learn developers
+# SPDX-License-Identifier: BSD-3-Clause
+
+import matplotlib.pyplot as plt
+import numpy as np
+from scipy.special import expit
+
+from sklearn import datasets
+from sklearn.linear_model import LinearRegression, LogisticRegression
+from sklearn.pipeline import make_pipeline
+from sklearn.preprocessing import StandardScaler
+from sklearn.svm import l1_min_c
+
+# %%
+# Part 1: Logistic Function
+# -------------------------
+#
+# This section shows how logistic regression classifies values as either 0 or 1
+# using the logistic curve, and compares it with linear regression.
+
+plt.figure(figsize=(10, 5))
+
+# Generate a toy dataset, it's just a straight line with some Gaussian noise:
+xmin, xmax = -5, 5
+n_samples = 100
+np.random.seed(0)
+X = np.random.normal(size=n_samples)
+y = (X > 0).astype(float)
+X[X > 0] *= 4
+X += 0.3 * np.random.normal(size=n_samples)
+
+X = X[:, np.newaxis]
+
+# Fit the classifier
+clf = LogisticRegression(C=1e5)
+clf.fit(X, y)
+
+# Plot the result
+plt.scatter(X.ravel(), y, label="example data", color="black", zorder=20)
+X_test = np.linspace(-5, 10, 300)
+
+loss = expit(X_test * clf.coef_ + clf.intercept_).ravel()
+plt.plot(X_test, loss, label="Logistic Regression Model", color="red", linewidth=3)
+
+ols = LinearRegression()
+ols.fit(X, y)
+plt.plot(
+    X_test,
+    ols.coef_ * X_test + ols.intercept_,
+    label="Linear Regression Model",
+    linewidth=1,
+)
+plt.axhline(0.5, color=".5")
+
+plt.ylabel("y")
+plt.xlabel("X")
+plt.xticks(range(-5, 10))
+plt.yticks([0, 0.5, 1])
+plt.ylim(-0.25, 1.25)
+plt.xlim(-4, 10)
+plt.legend(
+    loc="lower right",
+    fontsize="small",
+)
+plt.title("Logistic Function vs Linear Regression")
+
+# %%
+# Part 2: Regularization Path of L1-Logistic Regression
+# ----------------------------------------------------
+#
+# This section demonstrates how the coefficients of L1-regularized logistic regression
+# change as the regularization parameter changes. The models are ordered from strongest
+# regularized to least regularized.
+
+# Load data
+iris = datasets.load_iris()
+X = iris.data
+y = iris.target
+feature_names = iris.feature_names
+
+# Remove the third class to make the problem a binary classification
+X = X[y != 2]
+y = y[y != 2]
+
+# Compute regularization path
+cs = l1_min_c(X, y, loss="log") * np.logspace(0, 1, 16)
+
+# Create a pipeline with StandardScaler and LogisticRegression
+clf = make_pipeline(
+    StandardScaler(),
+    LogisticRegression(
+        penalty="l1",
+        solver="liblinear",
+        tol=1e-6,
+        max_iter=int(1e6),
+        warm_start=True,
+        fit_intercept=False,
+    ),
+)
+coefs_ = []
+for c in cs:
+    clf.set_params(logisticregression__C=c)
+    clf.fit(X, y)
+    coefs_.append(clf["logisticregression"].coef_.ravel().copy())
+
+coefs_ = np.array(coefs_)
+
+# Plot regularization path
+plt.figure(figsize=(10, 5))
+
+# Colorblind-friendly palette (IBM Color Blind Safe palette)
+colors = ["#648FFF", "#785EF0", "#DC267F", "#FE6100"]
+
+for i in range(coefs_.shape[1]):
+    plt.semilogx(cs, coefs_[:, i], marker="o", color=colors[i], label=feature_names[i])
+
+plt.xlabel("C (inverse of regularization strength)")
+plt.ylabel("Coefficients")
+plt.title("Regularization Path of L1-Logistic Regression")
+plt.legend()
+plt.axis("tight")
+
+plt.tight_layout()
+plt.show()

--- a/examples/linear_model/plot_regularization_paths.py
+++ b/examples/linear_model/plot_regularization_paths.py
@@ -1,0 +1,188 @@
+"""
+==============================================
+Regularization Paths for Linear Models
+==============================================
+
+This example illustrates the regularization paths for different linear models:
+
+1. **Ridge Regularization Path**: Shows how Ridge coefficients change with regularization
+   strength and demonstrates the effect of regularization on ill-conditioned matrices.
+
+2. **Lasso, Lasso-LARS, and Elastic Net Paths**: Compares the regularization paths of
+   these models, showing how coefficients change with regularization strength.
+
+Regularization is a technique used to prevent overfitting by adding a penalty term
+to the loss function. The regularization parameter controls the trade-off between
+fitting the data well and keeping the model simple.
+"""
+
+# Authors: The scikit-learn developers
+# SPDX-License-Identifier: BSD-3-Clause
+
+from itertools import cycle
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from sklearn.datasets import load_diabetes
+from sklearn.linear_model import enet_path, lars_path, lasso_path, Ridge
+
+# %%
+# Part 1: Ridge Regularization Path
+# ---------------------------------
+#
+# This section shows the effect of collinearity in the coefficients of a Ridge estimator.
+# Each color represents a different feature of the coefficient vector, and this is
+# displayed as a function of the regularization parameter.
+#
+# When alpha is very large, the regularization effect dominates the squared loss function
+# and the coefficients tend to zero. At the end of the path, as alpha tends toward zero
+# and the solution tends towards the ordinary least squares, coefficients exhibit big
+# oscillations.
+
+plt.figure(figsize=(10, 5))
+
+# X is the 10x10 Hilbert matrix
+X = 1.0 / (np.arange(1, 11) + np.arange(0, 10)[:, np.newaxis])
+y = np.ones(10)
+
+# Compute paths
+n_alphas = 200
+alphas = np.logspace(-10, -2, n_alphas)
+
+coefs = []
+for a in alphas:
+    ridge = Ridge(alpha=a, fit_intercept=False)
+    ridge.fit(X, y)
+    coefs.append(ridge.coef_)
+
+# Display results
+ax = plt.gca()
+
+ax.plot(alphas, coefs)
+ax.set_xscale("log")
+ax.set_xlim(ax.get_xlim()[::-1])  # reverse axis
+plt.xlabel("alpha (regularization strength)")
+plt.ylabel("coefficients")
+plt.title("Ridge Coefficients as a Function of Regularization")
+plt.axis("tight")
+
+# %%
+# Part 2: Lasso, Lasso-LARS, and Elastic Net Paths
+# ------------------------------------------------
+#
+# This section compares the regularization paths of Lasso, Lasso-LARS, and Elastic Net.
+# It shows how the coefficients change as the regularization strength changes.
+
+# Load the diabetes dataset
+X, y = load_diabetes(return_X_y=True)
+X /= X.std(axis=0)  # Standardize data (easier to set the l1_ratio parameter)
+
+# Compute paths
+eps = 5e-3  # the smaller it is the longer is the path
+
+print("Computing regularization path using the lasso...")
+alphas_lasso, coefs_lasso, _ = lasso_path(X, y, eps=eps)
+
+print("Computing regularization path using the positive lasso...")
+alphas_positive_lasso, coefs_positive_lasso, _ = lasso_path(
+    X, y, eps=eps, positive=True
+)
+
+print("Computing regularization path using the LARS...")
+alphas_lars, _, coefs_lars = lars_path(X, y, method="lasso")
+
+print("Computing regularization path using the positive LARS...")
+alphas_positive_lars, _, coefs_positive_lars = lars_path(
+    X, y, method="lasso", positive=True
+)
+
+print("Computing regularization path using the elastic net...")
+alphas_enet, coefs_enet, _ = enet_path(X, y, eps=eps, l1_ratio=0.8)
+
+print("Computing regularization path using the positive elastic net...")
+alphas_positive_enet, coefs_positive_enet, _ = enet_path(
+    X, y, eps=eps, l1_ratio=0.8, positive=True
+)
+
+# %%
+# Lasso vs LARS
+# -------------
+
+plt.figure(figsize=(10, 5))
+colors = cycle(["b", "r", "g", "c", "k"])
+for coef_lasso, coef_lars, c in zip(coefs_lasso, coefs_lars, colors):
+    l1 = plt.semilogx(alphas_lasso, coef_lasso, c=c)
+    l2 = plt.semilogx(alphas_lars, coef_lars, linestyle="--", c=c)
+
+plt.xlabel("alpha")
+plt.ylabel("coefficients")
+plt.title("Lasso and LARS Paths")
+plt.legend((l1[-1], l2[-1]), ("Lasso", "LARS"), loc="lower right")
+plt.axis("tight")
+
+# %%
+# Lasso vs Elastic-Net
+# --------------------
+
+plt.figure(figsize=(10, 5))
+colors = cycle(["b", "r", "g", "c", "k"])
+for coef_l, coef_e, c in zip(coefs_lasso, coefs_enet, colors):
+    l1 = plt.semilogx(alphas_lasso, coef_l, c=c)
+    l2 = plt.semilogx(alphas_enet, coef_e, linestyle="--", c=c)
+
+plt.xlabel("alpha")
+plt.ylabel("coefficients")
+plt.title("Lasso and Elastic-Net Paths")
+plt.legend((l1[-1], l2[-1]), ("Lasso", "Elastic-Net"), loc="lower right")
+plt.axis("tight")
+
+# %%
+# Lasso vs Positive Lasso
+# -----------------------
+
+plt.figure(figsize=(10, 5))
+colors = cycle(["b", "r", "g", "c", "k"])
+for coef_l, coef_pl, c in zip(coefs_lasso, coefs_positive_lasso, colors):
+    l1 = plt.semilogx(alphas_lasso, coef_l, c=c)
+    l2 = plt.semilogx(alphas_positive_lasso, coef_pl, linestyle="--", c=c)
+
+plt.xlabel("alpha")
+plt.ylabel("coefficients")
+plt.title("Lasso and Positive Lasso")
+plt.legend((l1[-1], l2[-1]), ("Lasso", "Positive Lasso"), loc="lower right")
+plt.axis("tight")
+
+# %%
+# LARS vs Positive LARS
+# ---------------------
+
+plt.figure(figsize=(10, 5))
+colors = cycle(["b", "r", "g", "c", "k"])
+for coef_lars, coef_positive_lars, c in zip(coefs_lars, coefs_positive_lars, colors):
+    l1 = plt.semilogx(alphas_lars, coef_lars, c=c)
+    l2 = plt.semilogx(alphas_positive_lars, coef_positive_lars, linestyle="--", c=c)
+
+plt.xlabel("alpha")
+plt.ylabel("coefficients")
+plt.title("LARS and Positive LARS")
+plt.legend((l1[-1], l2[-1]), ("LARS", "Positive LARS"), loc="lower right")
+plt.axis("tight")
+
+# %%
+# Elastic-Net vs Positive Elastic-Net
+# -----------------------------------
+
+plt.figure(figsize=(10, 5))
+colors = cycle(["b", "r", "g", "c", "k"])
+for coef_e, coef_pe, c in zip(coefs_enet, coefs_positive_enet, colors):
+    l1 = plt.semilogx(alphas_enet, coef_e, c=c)
+    l2 = plt.semilogx(alphas_positive_enet, coef_pe, linestyle="--", c=c)
+
+plt.xlabel("alpha")
+plt.ylabel("coefficients")
+plt.title("Elastic-Net and Positive Elastic-Net")
+plt.legend((l1[-1], l2[-1]), ("Elastic-Net", "Positive Elastic-Net"), loc="lower right")
+plt.axis("tight")
+
+plt.show()

--- a/examples/linear_model/plot_regularization_paths.py
+++ b/examples/linear_model/plot_regularization_paths.py
@@ -5,8 +5,9 @@ Regularization Paths for Linear Models
 
 This example illustrates the regularization paths for different linear models:
 
-1. **Ridge Regularization Path**: Shows how Ridge coefficients change with regularization
-   strength and demonstrates the effect of regularization on ill-conditioned matrices.
+1. **Ridge Regularization Path**: Shows how Ridge coefficients change with
+   regularization strength and demonstrates the effect of regularization on
+   ill-conditioned matrices.
 
 2. **Lasso, Lasso-LARS, and Elastic Net Paths**: Compares the regularization paths of
    these models, showing how coefficients change with regularization strength.
@@ -25,20 +26,20 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from sklearn.datasets import load_diabetes
-from sklearn.linear_model import enet_path, lars_path, lasso_path, Ridge
+from sklearn.linear_model import Ridge, enet_path, lars_path, lasso_path
 
 # %%
 # Part 1: Ridge Regularization Path
 # ---------------------------------
 #
-# This section shows the effect of collinearity in the coefficients of a Ridge estimator.
-# Each color represents a different feature of the coefficient vector, and this is
-# displayed as a function of the regularization parameter.
+# This section shows the effect of collinearity in the coefficients of a Ridge
+# estimator. Each color represents a different feature of the coefficient vector,
+# and this is displayed as a function of the regularization parameter.
 #
-# When alpha is very large, the regularization effect dominates the squared loss function
-# and the coefficients tend to zero. At the end of the path, as alpha tends toward zero
-# and the solution tends towards the ordinary least squares, coefficients exhibit big
-# oscillations.
+# When alpha is very large, the regularization effect dominates the squared loss
+# function and the coefficients tend to zero. At the end of the path, as alpha tends
+# toward zero and the solution tends towards the ordinary least squares, coefficients
+# exhibit big oscillations.
 
 plt.figure(figsize=(10, 5))
 

--- a/examples/linear_model/plot_sgd_overview.py
+++ b/examples/linear_model/plot_sgd_overview.py
@@ -1,0 +1,286 @@
+"""
+==============================================
+Stochastic Gradient Descent (SGD) - Overview
+==============================================
+
+This example illustrates various aspects of Stochastic Gradient Descent (SGD)
+in scikit-learn:
+
+1. **Loss Functions**: Visualization of different loss functions used in SGD
+2. **Penalties**: Visualization of L1, L2, and Elastic-Net penalties
+3. **Binary Classification**: Maximum margin separating hyperplane
+4. **Multi-class Classification**: Decision boundaries on the Iris dataset
+5. **Sample Weighting**: Effect of weighted samples on the decision boundary
+
+SGD is a simple yet efficient approach to fit linear models. It is particularly
+useful when the number of samples is very large or for online learning.
+"""
+
+# Authors: The scikit-learn developers
+# SPDX-License-Identifier: BSD-3-Clause
+
+import matplotlib.pyplot as plt
+import numpy as np
+from scipy.special import expit
+
+from sklearn import datasets, linear_model
+from sklearn.datasets import make_blobs
+from sklearn.inspection import DecisionBoundaryDisplay
+from sklearn.linear_model import SGDClassifier
+
+# %%
+# Part 1: SGD Loss Functions
+# --------------------------
+#
+# This section visualizes the various convex loss functions supported by
+# :class:`~sklearn.linear_model.SGDClassifier`.
+
+
+def modified_huber_loss(y_true, y_pred):
+    z = y_pred * y_true
+    loss = -4 * z
+    loss[z >= -1] = (1 - z[z >= -1]) ** 2
+    loss[z >= 1.0] = 0
+    return loss
+
+
+plt.figure(figsize=(10, 5))
+xmin, xmax = -4, 4
+xx = np.linspace(xmin, xmax, 100)
+lw = 2
+plt.plot([xmin, 0, 0, xmax], [1, 1, 0, 0], color="gold", lw=lw, label="Zero-one loss")
+plt.plot(xx, np.where(xx < 1, 1 - xx, 0), color="teal", lw=lw, label="Hinge loss")
+plt.plot(xx, -np.minimum(xx, 0), color="yellowgreen", lw=lw, label="Perceptron loss")
+plt.plot(xx, np.log2(1 + np.exp(-xx)), color="cornflowerblue", lw=lw, label="Log loss")
+plt.plot(
+    xx,
+    np.where(xx < 1, 1 - xx, 0) ** 2,
+    color="orange",
+    lw=lw,
+    label="Squared hinge loss",
+)
+plt.plot(
+    xx,
+    modified_huber_loss(xx, 1),
+    color="darkorchid",
+    lw=lw,
+    linestyle="--",
+    label="Modified Huber loss",
+)
+plt.ylim((0, 8))
+plt.legend(loc="upper right")
+plt.xlabel(r"Decision function $f(x)$")
+plt.ylabel("$L(y=1, f(x))$")
+plt.title("SGD Loss Functions")
+
+# %%
+# Part 2: SGD Penalties
+# ---------------------
+#
+# This section shows contours of where the penalty is equal to 1
+# for the three penalties L1, L2 and elastic-net.
+
+plt.figure(figsize=(10, 5))
+l1_color = "navy"
+l2_color = "c"
+elastic_net_color = "darkorange"
+
+line = np.linspace(-1.5, 1.5, 1001)
+xx, yy = np.meshgrid(line, line)
+
+l2 = xx**2 + yy**2
+l1 = np.abs(xx) + np.abs(yy)
+rho = 0.5
+elastic_net = rho * l1 + (1 - rho) * l2
+
+ax = plt.gca()
+
+elastic_net_contour = plt.contour(
+    xx, yy, elastic_net, levels=[1], colors=elastic_net_color
+)
+l2_contour = plt.contour(xx, yy, l2, levels=[1], colors=l2_color)
+l1_contour = plt.contour(xx, yy, l1, levels=[1], colors=l1_color)
+ax.set_aspect("equal")
+ax.spines["left"].set_position("center")
+ax.spines["right"].set_color("none")
+ax.spines["bottom"].set_position("center")
+ax.spines["top"].set_color("none")
+
+plt.clabel(
+    elastic_net_contour,
+    inline=1,
+    fontsize=12,
+    fmt={1.0: "elastic-net"},
+    manual=[(-1, -1)],
+)
+plt.clabel(l2_contour, inline=1, fontsize=12, fmt={1.0: "L2"}, manual=[(-1, -1)])
+plt.clabel(l1_contour, inline=1, fontsize=12, fmt={1.0: "L1"}, manual=[(-1, -1)])
+plt.title("SGD Penalties")
+
+# %%
+# Part 3: Maximum Margin Separating Hyperplane
+# --------------------------------------------
+#
+# This section demonstrates a linear Support Vector Machines classifier
+# trained using SGD to find the maximum margin separating hyperplane
+# within a two-class separable dataset.
+
+plt.figure(figsize=(10, 5))
+
+# Create 50 separable points
+X, Y = make_blobs(n_samples=50, centers=2, random_state=0, cluster_std=0.60)
+
+# Fit the model
+clf = SGDClassifier(loss="hinge", alpha=0.01, max_iter=200)
+clf.fit(X, Y)
+
+# Plot the line, the points, and the nearest vectors to the plane
+xx = np.linspace(-1, 5, 10)
+yy = np.linspace(-1, 5, 10)
+
+X1, X2 = np.meshgrid(xx, yy)
+Z = np.empty(X1.shape)
+for (i, j), val in np.ndenumerate(X1):
+    x1 = val
+    x2 = X2[i, j]
+    p = clf.decision_function([[x1, x2]])
+    Z[i, j] = p[0]
+levels = [-1.0, 0.0, 1.0]
+linestyles = ["dashed", "solid", "dashed"]
+colors = "k"
+plt.contour(X1, X2, Z, levels, colors=colors, linestyles=linestyles)
+plt.scatter(X[:, 0], X[:, 1], c=Y, cmap=plt.cm.Paired, edgecolor="black", s=20)
+plt.axis("tight")
+plt.title("SGD: Maximum Margin Separating Hyperplane")
+
+# %%
+# Part 4: Multi-class SGD on the Iris Dataset
+# -------------------------------------------
+#
+# This section demonstrates multi-class classification using SGD on the iris dataset.
+# The hyperplanes corresponding to the three one-versus-all (OVA) classifiers
+# are represented by the dashed lines.
+
+plt.figure(figsize=(10, 5))
+
+# Import iris data
+iris = datasets.load_iris()
+
+# We only take the first two features
+X = iris.data[:, :2]
+y = iris.target
+colors = "bry"
+
+# Shuffle
+idx = np.arange(X.shape[0])
+np.random.seed(13)
+np.random.shuffle(idx)
+X = X[idx]
+y = y[idx]
+
+# Standardize
+mean = X.mean(axis=0)
+std = X.std(axis=0)
+X = (X - mean) / std
+
+clf = SGDClassifier(alpha=0.001, max_iter=100).fit(X, y)
+ax = plt.gca()
+DecisionBoundaryDisplay.from_estimator(
+    clf,
+    X,
+    cmap=plt.cm.Paired,
+    ax=ax,
+    response_method="predict",
+    xlabel=iris.feature_names[0],
+    ylabel=iris.feature_names[1],
+)
+plt.axis("tight")
+
+# Plot also the training points
+for i, color in zip(clf.classes_, colors):
+    idx = np.where(y == i)
+    plt.scatter(
+        X[idx, 0],
+        X[idx, 1],
+        c=color,
+        label=iris.target_names[i],
+        edgecolor="black",
+        s=20,
+    )
+plt.title("Decision Surface of Multi-class SGD")
+
+# Plot the three one-against-all classifiers
+xmin, xmax = plt.xlim()
+ymin, ymax = plt.ylim()
+coef = clf.coef_
+intercept = clf.intercept_
+
+
+def plot_hyperplane(c, color):
+    def line(x0):
+        return (-(x0 * coef[c, 0]) - intercept[c]) / coef[c, 1]
+
+    plt.plot([xmin, xmax], [line(xmin), line(xmax)], ls="--", color=color)
+
+
+for i, color in zip(clf.classes_, colors):
+    plot_hyperplane(i, color)
+plt.legend()
+
+# %%
+# Part 5: SGD with Weighted Samples
+# ---------------------------------
+#
+# This section demonstrates the effect of sample weighting on the decision boundary.
+# The size of points is proportional to its weight.
+
+plt.figure(figsize=(10, 5))
+
+# Create 20 points
+np.random.seed(0)
+X = np.r_[np.random.randn(10, 2) + [1, 1], np.random.randn(10, 2)]
+y = [1] * 10 + [-1] * 10
+sample_weight = 100 * np.abs(np.random.randn(20))
+# Assign a bigger weight to the last 10 samples
+sample_weight[:10] *= 10
+
+# Plot the weighted data points
+xx, yy = np.meshgrid(np.linspace(-4, 5, 500), np.linspace(-4, 5, 500))
+ax = plt.gca()
+ax.scatter(
+    X[:, 0],
+    X[:, 1],
+    c=y,
+    s=sample_weight,
+    alpha=0.9,
+    cmap=plt.cm.bone,
+    edgecolor="black",
+)
+
+# Fit the unweighted model
+clf = linear_model.SGDClassifier(alpha=0.01, max_iter=100)
+clf.fit(X, y)
+Z = clf.decision_function(np.c_[xx.ravel(), yy.ravel()])
+Z = Z.reshape(xx.shape)
+no_weights = ax.contour(xx, yy, Z, levels=[0], linestyles=["solid"])
+
+# Fit the weighted model
+clf = linear_model.SGDClassifier(alpha=0.01, max_iter=100)
+clf.fit(X, y, sample_weight=sample_weight)
+Z = clf.decision_function(np.c_[xx.ravel(), yy.ravel()])
+Z = Z.reshape(xx.shape)
+samples_weights = ax.contour(xx, yy, Z, levels=[0], linestyles=["dashed"])
+
+no_weights_handles, _ = no_weights.legend_elements()
+weights_handles, _ = samples_weights.legend_elements()
+ax.legend(
+    [no_weights_handles[0], weights_handles[0]],
+    ["no weights", "with weights"],
+    loc="lower left",
+)
+
+ax.set(xticks=(), yticks=())
+plt.title("SGD: Effect of Weighted Samples")
+
+plt.tight_layout()
+plt.show()

--- a/sklearn/linear_model/_coordinate_descent.py
+++ b/sklearn/linear_model/_coordinate_descent.py
@@ -319,8 +319,8 @@ def lasso_path(
     Notes
     -----
     For an example, see
-    :ref:`examples/linear_model/plot_lasso_lasso_lars_elasticnet_path.py
-    <sphx_glr_auto_examples_linear_model_plot_lasso_lasso_lars_elasticnet_path.py>`.
+    :ref:`examples/linear_model/plot_regularization_paths.py
+    <sphx_glr_auto_examples_linear_model_plot_regularization_paths.py>`.
 
     To avoid unnecessary memory duplication the X argument of the fit method
     should be directly passed as a Fortran-contiguous numpy array.
@@ -524,8 +524,8 @@ def enet_path(
     Notes
     -----
     For an example, see
-    :ref:`examples/linear_model/plot_lasso_lasso_lars_elasticnet_path.py
-    <sphx_glr_auto_examples_linear_model_plot_lasso_lasso_lars_elasticnet_path.py>`.
+    :ref:`examples/linear_model/plot_regularization_paths.py
+    <sphx_glr_auto_examples_linear_model_plot_regularization_paths.py>`.
 
     Examples
     --------

--- a/sklearn/linear_model/_stochastic_gradient.py
+++ b/sklearn/linear_model/_stochastic_gradient.py
@@ -993,7 +993,7 @@ class SGDClassifier(BaseSGDClassifier):
         More details about the losses formulas can be found in the :ref:`User Guide
         <sgd_mathematical_formulation>` and you can find a visualisation of the loss
         functions in
-        :ref:`sphx_glr_auto_examples_linear_model_plot_sgd_loss_functions.py`.
+        :ref:`sphx_glr_auto_examples_linear_model_plot_sgd_overview.py`.
 
     penalty : {'l2', 'l1', 'elasticnet', None}, default='l2'
         The penalty (aka regularization term) to be used. Defaults to 'l2'
@@ -1002,7 +1002,7 @@ class SGDClassifier(BaseSGDClassifier):
         not achievable with 'l2'. No penalty is added when set to `None`.
 
         You can see a visualisation of the penalties in
-        :ref:`sphx_glr_auto_examples_linear_model_plot_sgd_penalties.py`.
+        :ref:`sphx_glr_auto_examples_linear_model_plot_sgd_overview.py`.
 
     alpha : float, default=0.0001
         Constant that multiplies the regularization term. The higher the
@@ -1826,7 +1826,7 @@ class SGDRegressor(BaseSGDRegressor):
         not achievable with 'l2'. No penalty is added when set to `None`.
 
         You can see a visualisation of the penalties in
-        :ref:`sphx_glr_auto_examples_linear_model_plot_sgd_penalties.py`.
+        :ref:`sphx_glr_auto_examples_linear_model_plot_sgd_overview.py`.
 
     alpha : float, default=0.0001
         Constant that multiplies the regularization term. The higher the

--- a/sklearn/svm/_bounds.py
+++ b/sklearn/svm/_bounds.py
@@ -34,7 +34,7 @@ def l1_min_c(X, y, *, loss="squared_hinge", fit_intercept=True, intercept_scalin
     This value is valid if `class_weight` parameter in `fit()` is not set.
 
     For an example of how to use this function, see
-    :ref:`sphx_glr_auto_examples_linear_model_plot_logistic_path.py`.
+    :ref:`sphx_glr_auto_examples_linear_model_plot_logistic_regression_overview.py`.
 
     Parameters
     ----------


### PR DESCRIPTION
This PR merges several short examples under `examples/linear_model` that cover similar concepts to create more comprehensive examples.

### Changes

1. **SGD-related examples**:
   - Created `plot_sgd_overview.py` that combines 5 original examples
   - Updated references in `sklearn/linear_model/_stochastic_gradient.py`
   - Updated references in `doc/modules/sgd.rst`

2. **Logistic Regression examples**:
   - Created `plot_logistic_regression_overview.py` that combines 2 original examples
   - Updated references in `sklearn/svm/_bounds.py`
   - Updated references in `doc/modules/linear_model.rst`

3. **Regularization Path examples**:
   - Created `plot_regularization_paths.py` that combines 2 original examples
   - Updated references in `sklearn/linear_model/_coordinate_descent.py`
   - Updated references in `doc/modules/linear_model.rst`

4. **Documentation**:
   - Created a README file (`README_MERGED_EXAMPLES.txt`) to document the merged examples

The original examples have been preserved for backward compatibility, but references in the documentation and codebase have been updated to point to the new merged examples.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author