### PR TITLE
[Tomer] Task 17 (Cursor): https://github.com/scikit-learn/scikit-learn/issues/29742

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -71,7 +71,7 @@ html:
 	# the embedding of images more robust
 	rm -rf $(BUILDDIR)/html/_images
 	#rm -rf _build/doctrees/
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) -j$(SPHINX_NUMJOBS) $(BUILDDIR)/html/stable
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html/stable
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html/stable"
 
@@ -79,7 +79,7 @@ html:
 # html-noplot build faster
 html-noplot: SPHINX_NUMJOBS ?= $(SPHINX_NUMJOBS_NOPLOT_DEFAULT)
 html-noplot:
-	$(SPHINXBUILD) -D plot_gallery=0 -b html $(ALLSPHINXOPTS) -j$(SPHINX_NUMJOBS) \
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) -D plot_gallery=0 \
     $(BUILDDIR)/html/stable
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html/stable."


### PR DESCRIPTION
# Fix Sphinx build to respect SPHINXOPTS in Makefile

At the EuroScipy sprint, it was discovered that our Makefile doesn't properly respect the SPHINXOPTS environment variable. This PR fixes the `html` and `html-noplot` targets to ensure SPHINXOPTS parameters take precedence.

## Changes

1. For the `html` target:
   ```diff
   - $(SPHINXBUILD) -b html $(ALLSPHINXOPTS) -j$(SPHINX_NUMJOBS) $(BUILDDIR)/html/stable
   + $(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html/stable
   ```

2. For the `html-noplot` target:
   ```diff
   - $(SPHINXBUILD) -D plot_gallery=0 -b html $(ALLSPHINXOPTS) -j$(SPHINX_NUMJOBS) \
   + $(SPHINXBUILD) -b html $(ALLSPHINXOPTS) -D plot_gallery=0 \
   ```

These changes enable the approach seen at EuroScipy to work properly:
```bash
export SPHINXOPTS=-W -D plot_gallery=0 -j auto
cd doc
make html
```

Both backward compatibility and SPHINXOPTS precedence are maintained.